### PR TITLE
Recap and condensed game change highlight fix

### DIFF
--- a/src/GameDetails/GameDetails.js
+++ b/src/GameDetails/GameDetails.js
@@ -19,7 +19,7 @@ class GameDetails extends Component {
     let highlights = await getHighlights(this.props.location.state.id);
     highlights = await this.filterHighlights(highlights);
     this.props.setHighlights(highlights);
-    this.setState({bigHighlight: this.state.condensedGame || this.state.recap || this.props.highlights[0]});
+    this.setState({bigHighlight: this.state.recap || this.state.condensedGame|| this.props.highlights[0]});
   }
   filterHighlights = (highlights) => {
     highlights = highlights.map(highlight => {
@@ -53,16 +53,18 @@ class GameDetails extends Component {
     return time.join('');
   }
   changeHighlight = ({id}) => {
-    const bigHighlight = this.props.highlights.find(highlight => highlight.id === id);
+    const { condensedGame, recap } = this.state;
+    let bigHighlight = this.props.highlights.find(highlight => highlight.id === id);
+    if (condensedGame.id === id) { bigHighlight = condensedGame}
+    if (recap.id === id) { bigHighlight = recap }
     this.setState({bigHighlight});
   }
   render() {
-    const { condensedGame, recap } = this.state;
+    const { condensedGame, recap, bigHighlight } = this.state;
     const game = this.props.location.state;
     const highlights = this.props.highlights.map(highlight => {
       return <HighlightCard key={highlight.id} highlight={highlight} />
     });
-    const { bigHighlight } = this.state;
 
     return (
       <article className="game-details">
@@ -81,6 +83,7 @@ class GameDetails extends Component {
             alt={ `${game.awayTeam.name} logo` }
           />
         </div>
+
         <p className="more-highlights-heading">More Highlights:</p>
 
         <section className="big-video-container">

--- a/src/GameDetails/GameDetails.scss
+++ b/src/GameDetails/GameDetails.scss
@@ -32,15 +32,18 @@
   font-weight: 400;
   margin: 0;
   text-shadow: 3px 2px 2px #1f2833;
+  width: 40%;
+  text-align: center;
 }
 
 .score-text {
+  border-left: 3px solid $blueaqua;
+  border-right: 3px solid $blueaqua;
+  background: $carbon;
+  padding: 1.2% 1.2%;
   color: $white;
-  font-size: 1.7vw;
+  font-size: 1.5vw;
   margin: 0;
-  display: inline-block;
-  vertical-align: middle;
-  line-height: 2;
 }
 
 .game-heading-logo {

--- a/src/GameDetails/GameDetails.scss
+++ b/src/GameDetails/GameDetails.scss
@@ -1,14 +1,14 @@
 @import '../variables.scss';
 
 .game-details {
-  padding: 0% 4%;
+  padding: 0% 10%;
   margin-top: 100px;
   display: grid;
   justify-content: center;
-  grid-template-columns: 75% 25%;
+  grid-template-columns: 72.5% 5% 22.5%;
   grid-template-areas:
-    "heading highlights-heading"
-    "bigvid thumbs";
+    "heading empty morehighlights"
+    "bigvid empty thumbs";
 }
 
 .game-title-bar {
@@ -18,16 +18,17 @@
   flex-direction: row;
   justify-content: space-between;
   align-items: center;
-  width: 94%;
+  width: 99%;
   background: rgba(173,216,229,0.3);
   border-radius: 10px;
   box-shadow: 3px 3px 6px 1px black;
+  margin-right: 5%;
 }
 
 .game-title-heading {
   color: $blueaqua;
   font-family: $raleway;
-  font-size: 1.8vw;
+  font-size: 1.5vw;
   font-weight: 400;
   margin: 0;
   text-shadow: 3px 2px 2px #1f2833;
@@ -52,6 +53,7 @@
 }
 
 .more-highlights-heading {
+  grid-area: morehighlights;
   color: $white;
   text-align: center;
   display: flex;
@@ -67,7 +69,8 @@
   grid-area: bigvid;
   align-items: left;
   width: 100%;
-  padding-top: 2%;
+  padding-top: 4%;
+  margin-right: 2%;
 }
 
 .big-vid-title {
@@ -78,6 +81,7 @@
 .scroll-container {
   grid-area: thumbs;
   padding-top: 2%;
+  width:100%;
 }
 
 .highlight-container {
@@ -91,6 +95,7 @@
   height: 65vh;
   position: relative;
   overflow-y: scroll;
+  margin: 0;
 }
 
 .scroll-up-arrow {

--- a/src/GameDetails/GameDetails.scss
+++ b/src/GameDetails/GameDetails.scss
@@ -75,7 +75,7 @@
 
 .big-vid-title {
   margin: 0;
-  font-size: 2vw;
+  font-size: 1.5vw;
 }
 
 .scroll-container {
@@ -92,7 +92,7 @@
   display: flex;
   flex-direction: column;
   width: 100%;
-  height: 65vh;
+  height: 62.5vh;
   position: relative;
   overflow-y: scroll;
   margin: 0;

--- a/src/HighlightCard/HighlightCard.js
+++ b/src/HighlightCard/HighlightCard.js
@@ -4,7 +4,7 @@ import './HighlightCard.scss';
 
 export const HighlightCard = ({highlight, bigVid}) => {
   const featureVid = (
-    <video className="highlight-vid" align="left" controls loop>
+    <video className="highlight-vid" align="left" controls autoplay="autoplay" loop>
       <source src={highlight.videoURL} type="video/mp4"/>
       Your browser does not support the video tag.
     </video>

--- a/src/HighlightCard/HighlightCard.scss
+++ b/src/HighlightCard/HighlightCard.scss
@@ -16,7 +16,6 @@
 }
 
 .highlight-preview {
-  border: 1px solid $blueaqua;
   cursor: pointer;
   position: relative;
   display: flex;

--- a/src/HighlightCard/HighlightCard.scss
+++ b/src/HighlightCard/HighlightCard.scss
@@ -5,14 +5,15 @@
   flex-direction: column;
   align-self: center;
   margin: 7.5px 0px;
-  width: 95%;
+  width: 90%;
 }
 
 .highlight-vid {
+  border: 3px solid $blueaqua;
   cursor: pointer;
   object-fit: cover;
   outline: none;
-  width: 100%;
+  width: 110%;
 }
 
 .highlight-preview {
@@ -36,7 +37,7 @@
   -webkit-text-fill-color: $white; /* Will override color (regardless of order) */
   -webkit-text-stroke-width: 0.5px;
   -webkit-text-stroke-color: $blueaqua;
-  font-size: 1.7vw;
+  font-size: 1.2vw;
   font-weight: 400;
   padding: 0;
   text-align: right;


### PR DESCRIPTION
#### What's this PR do?
- Adds a fix in functionality so user can play condensed game and recap
- Adds autoplay to videos
- Remove border from highlight thumbnails and added to big video highlight
- Fixes the scale to give more room on the bottom of the page
- Change style of game title bar on game details page

#### How should this be manually tested?
Click on the condensed game or recap from the highlight container. Note: You will need to find a game with one of these. Not all games have them.

#### What are the relevant tickets?
n/a

#### Future Implementation Plans:
- Add functionality for user choosing date
- Add functionality to bring down menu with "Must C Highlights (Coming Soon)", etc.
- Add functionality for user to login (stretch goal)

#### Questions/Comments:
