### PR TITLE
Add clean date and video playbacks expansion

### DIFF
--- a/src/GameDetails/GameDetails.js
+++ b/src/GameDetails/GameDetails.js
@@ -39,7 +39,9 @@ class GameDetails extends Component {
     return this.grabCondensedAndRecap(highlights);
   }
   findVideoURL = (highlight) => {
-    return highlight.playbacks.find(pb => pb.url.includes('1280x720')).url;
+    return highlight.playbacks.find(pb => {
+      return pb.url.includes('1280x720') || pb.url.includes('2500K');
+    }).url;
   }
   grabCondensedAndRecap = (highlights) => {
     highlights.forEach((highlight, i) => {

--- a/src/GamesContainer/GamesContainer.js
+++ b/src/GamesContainer/GamesContainer.js
@@ -28,7 +28,7 @@ class GamesContainer extends Component {
     const months = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"]
     const month = `${String(date.getMonth()+1).length < 2 ? 0 : ''}${date.getMonth()+1}`;
     const day = `${String(date.getDate()).length < 2 ? 0 : ''}${date.getDate()}`;
-    return {month, day, year: date.getFullYear(), monthABC: months[month-1]}
+    return {cleanDate: date, month, day, year: date.getFullYear(), monthABC: months[month-1]}
   }
   filterGames = (games) => {
     return games.map(game => {
@@ -59,7 +59,7 @@ class GamesContainer extends Component {
             <h2>{date.monthABC} {parseInt(date.day)}, {date.year}</h2>
             <DatePicker
               className="game-date-picker"
-              selected={new Date()}
+              selected={this.props.date.cleanDate}
               onSelect={this.handleChange}
             />
             <img src={process.env.PUBLIC_URL + '/calendar.png'} alt="calendar" />


### PR DESCRIPTION
#### What's this PR do?
- Adds a clean date key to the date object in the global store
  - This allows us to use that date in other parts of the code where it's needed and there's no way to manipulate it back to a clean date
- Adds another search for 2500K videos as a backup if there are no 1280x720 playbacks
  - might need to add more in the future if the api changes

#### How should this be manually tested?
Checkout the redux state to see the new object of cleanDate

#### What are the relevant tickets?
n/a

#### Future Implementation Plans:


#### Questions/Comments:
